### PR TITLE
Use correct Pillow anchor for top-left text

### DIFF
--- a/generate_schedule.py
+++ b/generate_schedule.py
@@ -45,7 +45,7 @@ def main():
             stroke_width=preset.style.stroke_width,
             stroke_fill=preset.style.stroke_fill,
             align="left",
-            anchor="nw",
+            anchor="lt",
         )
     base.save(args.output)
     print("saved", args.output)

--- a/schedule/editor.py
+++ b/schedule/editor.py
@@ -219,7 +219,7 @@ class TelopEditor(tk.Tk):
                 align="left",
                 stroke_width=stroke_w,
                 stroke_fill=self.style.stroke_fill,
-                anchor="nw",
+                anchor="lt",
             )
 
         suggested = self._suggest_filename()
@@ -419,13 +419,13 @@ class TelopEditor(tk.Tk):
             # テキストのサイズを取得
             text = it.text if it.text else " "
             bbox = ImageDraw.Draw(Image.new("RGBA", (1, 1))).multiline_textbbox(
-                (0, 0), text, font=font, spacing=spacing, align="left", stroke_width=stroke_w, anchor="nw")
+                (0, 0), text, font=font, spacing=spacing, align="left", stroke_width=stroke_w, anchor="lt")
             w = max(1, bbox[2] - bbox[0])
             h = max(1, bbox[3] - bbox[1])
             img = Image.new("RGBA", (w, h), (0, 0, 0, 0))
             d = ImageDraw.Draw(img)
             d.multiline_text((0, 0), text, font=font, fill=self.style.fill, spacing=spacing,
-                             align="left", stroke_width=stroke_w, stroke_fill=self.style.stroke_fill, anchor="nw")
+                             align="left", stroke_width=stroke_w, stroke_fill=self.style.stroke_fill, anchor="lt")
             ph = ImageTk.PhotoImage(img)
             x, y = it.pos
             self.canvas.create_image(x, y, image=ph, anchor="nw", tags=("telop", f"telop_{idx}"))


### PR DESCRIPTION
## Summary
- fix font changing crash by replacing invalid `nw` anchor with Pillow's `lt` anchor
- update schedule generator to use the same anchor

## Testing
- `python -m py_compile schedule/editor.py generate_schedule.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7cb4631f0832da99e5f70d51e4de0